### PR TITLE
set io_handle default codepage to codepage is setted

### DIFF
--- a/liblnk/liblnk_io_handle.c
+++ b/liblnk/liblnk_io_handle.c
@@ -104,6 +104,10 @@ int liblnk_io_handle_initialize(
 		goto on_error;
 	}
 	( *io_handle )->ascii_codepage = LIBLNK_CODEPAGE_WINDOWS_1252;
+	if(liblnk_get_codepage(&((*io_handle)->ascii_codepage), &error) != 1)
+	{
+		goto on_error;
+	}
 
 	return( 1 );
 
@@ -730,4 +734,3 @@ on_error:
 #endif
 	return( -1 );
 }
-


### PR DESCRIPTION
set io_handle default codepage to codepage is setted by liblnk_set_codepage