### PR TITLE
liblnk: Fix incorrect re-use of file_information->size

### DIFF
--- a/liblnk/liblnk_file.c
+++ b/liblnk/liblnk_file.c
@@ -2623,7 +2623,7 @@ int liblnk_file_get_show_window_value(
 
 		return( -1 );
 	}
-	*show_window_value = internal_file->file_information->size;
+	*show_window_value = internal_file->file_information->show_window;
 
 	return( 1 );
 }
@@ -2674,7 +2674,7 @@ int liblnk_file_get_hot_key_value(
 
 		return( -1 );
 	}
-	*hot_key_value = internal_file->file_information->size;
+	*hot_key_value = internal_file->file_information->hot_key;
 
 	return( 1 );
 }


### PR DESCRIPTION
Fix incorrect re-use of internal_file->file_information->size in functions for show_window and hot_key